### PR TITLE
Always prompt for confirmation in TTY even with -f flag

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -49,8 +49,10 @@ fn process_target(
         }
     }
 
-    // Prompt for confirmation (skip if -f)
-    if !cli.force {
+    // Always prompt when connected to a TTY; skip only with -f in non-TTY (scripts/CI)
+    let should_prompt = std::io::IsTerminal::is_terminal(&std::io::stdin()) || !cli.force;
+
+    if should_prompt {
         let msg = if target.is_dir() {
             t!("confirm_trash_dir", name = target.display().to_string())
         } else {


### PR DESCRIPTION
## Summary
- Always show confirmation prompt in interactive TTY sessions, even when `-f` is passed
- Only skip prompt with `-f` in non-TTY environments (scripts/CI)

## Test plan
- [x] All 27 tests pass (`cargo test`)
- [ ] Manual: run `saferm -f <file>` in terminal → should still prompt
- [ ] Manual: pipe `echo | saferm -f <file>` → should skip prompt

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)