### PR TITLE
feat: add manual release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,9 +36,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          git checkout -B main origin/main
-
-          current_version="$(
+          read_current_version() {
             awk '
               /^\[package\]$/ { in_package = 1; next }
               /^\[.*\]$/ { in_package = 0 }
@@ -49,33 +47,100 @@ jobs:
                 exit
               }
             ' Cargo.toml
-          )"
+          }
+
+          git checkout -B main origin/main
+
+          current_version="$(read_current_version)"
 
           if [[ -z "$current_version" ]]; then
             echo "failed to resolve the current package version from Cargo.toml" >&2
             exit 1
           fi
 
-          if [[ -z "${{ inputs.version }}" ]]; then
-            current_tag="v$current_version"
-            current_subject="chore: release $current_tag"
+          head_sha="$(git rev-parse HEAD)"
+          head_subject="$(git log -1 --format=%s)"
+          recovery_mode=false
+          release_version=""
+          release_tag=""
 
-            if ! git rev-parse -q --verify "refs/tags/$current_tag" >/dev/null &&
-              git log --format=%s | grep -Fxq "$current_subject"; then
-              echo "main already contains an unpublished release commit for $current_tag; recover the in-flight release instead of starting a new patch bump" >&2
+          if [[ "$head_subject" =~ ^chore:\ release\ (v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            head_release_tag="${BASH_REMATCH[1]}"
+            if [[ "$head_release_tag" == "v$current_version" ]]; then
+              recovery_mode=true
+              release_version="$current_version"
+              release_tag="$head_release_tag"
+            fi
+          fi
+
+          requested_version="${{ inputs.version }}"
+
+          if [[ -z "$requested_version" ]]; then
+            if [[ "$recovery_mode" != true ]]; then
+              while IFS=$'\t' read -r commit subject; do
+                [[ -n "$commit" ]] || continue
+
+                release_tag_from_history="${subject#chore: release }"
+                if git rev-parse -q --verify "refs/tags/$release_tag_from_history" >/dev/null; then
+                  tag_sha="$(git rev-parse "$release_tag_from_history^{}")"
+                  if [[ "$tag_sha" != "$commit" ]]; then
+                    echo "tag $release_tag_from_history already exists at a different commit" >&2
+                    exit 1
+                  fi
+                  continue
+                fi
+
+                echo "main already contains an unpublished release commit for $release_tag_from_history; recover the in-flight release instead of starting a new patch bump" >&2
+                exit 1
+              done < <(git log --format='%H%x09%s' --grep '^chore: release v[0-9]\+\.[0-9]\+\.[0-9]\+$')
+            fi
+          else
+            requested_release_version="$(bash scripts/release/resolve-version.sh "$requested_version" "$current_version")"
+            requested_release_tag="v$requested_release_version"
+
+            if [[ "$recovery_mode" == true && "$requested_release_tag" == "$release_tag" ]]; then
+              :
+            else
+              recovery_mode=false
+              release_version="$requested_release_version"
+              release_tag="$requested_release_tag"
+              if [[ "$release_version" == "$current_version" ]]; then
+                echo "requested version matches the current package version, but origin/main is not the corresponding release commit to recover" >&2
+                exit 1
+              fi
+            fi
+          fi
+
+          if [[ "$recovery_mode" != true ]]; then
+            release_version="$(bash scripts/release/resolve-version.sh "${requested_version}" "$current_version")"
+            release_tag="v$release_version"
+          fi
+
+          if git rev-parse -q --verify "refs/tags/$release_tag" >/dev/null; then
+            tag_sha="$(git rev-parse "$release_tag^{}")"
+            if [[ "$recovery_mode" == true && "$tag_sha" == "$head_sha" ]]; then
+              :
+            else
+              echo "tag $release_tag already exists at a different commit" >&2
               exit 1
             fi
           fi
 
-          release_version="$(bash scripts/release/resolve-version.sh "${{ inputs.version }}" "$current_version")"
-          release_tag="v$release_version"
+          if [[ "$recovery_mode" == true ]]; then
+            base_sha="$(git rev-parse "$head_sha^")"
+            release_sha="$head_sha"
+            git update-ref refs/heads/release-candidate "$release_sha"
 
-          if git rev-parse -q --verify "refs/tags/$release_tag" >/dev/null; then
-            echo "tag already exists: $release_tag" >&2
-            exit 1
+            {
+              echo "base_sha=$base_sha"
+              echo "release_sha=$release_sha"
+              echo "release_tag=$release_tag"
+              echo "release_version=$release_version"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-          base_sha="$(git rev-parse HEAD)"
+          base_sha="$head_sha"
 
           bash scripts/release/update-version.sh Cargo.toml Cargo.lock "$release_version"
 
@@ -117,11 +182,13 @@ jobs:
           - target: x86_64-unknown-linux-musl
             runner: ubuntu-latest
             use-cross: true
-            run-validation: true
+            run-style-checks: true
+            run-tests: true
           - target: aarch64-apple-darwin
             runner: macos-latest
             use-cross: false
-            run-validation: false
+            run-style-checks: false
+            run-tests: true
     steps:
       - name: Checkout main
         uses: actions/checkout@v6
@@ -178,11 +245,15 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
-      - name: Validate release candidate
-        if: ${{ matrix.run-validation }}
+      - name: Run fmt and clippy
+        if: ${{ matrix.run-style-checks }}
         run: |
           cargo fmt -- --check
           cargo clippy -- -D warnings
+
+      - name: Run tests
+        if: ${{ matrix.run-tests }}
+        run: |
           cargo test
 
       - name: Install cross

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,15 +1,114 @@
 name: Release
 
 on:
-  push:
-    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version (X.Y.Z). Leave empty to bump the current patch version.
+        required: false
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    name: Build ${{ matrix.target }}
+  prepare:
+    name: Prepare release candidate
+    runs-on: ubuntu-latest
+    outputs:
+      base_sha: ${{ steps.prepare.outputs.base_sha }}
+      release_sha: ${{ steps.prepare.outputs.release_sha }}
+      release_tag: ${{ steps.prepare.outputs.release_tag }}
+      release_version: ${{ steps.prepare.outputs.release_version }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Fetch main and tags
+        run: git fetch --force --tags origin main
+
+      - name: Prepare release commit
+        id: prepare
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git checkout -B main origin/main
+
+          current_version="$(
+            awk '
+              /^\[package\]$/ { in_package = 1; next }
+              /^\[.*\]$/ { in_package = 0 }
+              in_package && /^version = "/ {
+                gsub(/^version = "/, "", $0)
+                gsub(/"$/, "", $0)
+                print
+                exit
+              }
+            ' Cargo.toml
+          )"
+
+          if [[ -z "$current_version" ]]; then
+            echo "failed to resolve the current package version from Cargo.toml" >&2
+            exit 1
+          fi
+
+          if [[ -z "${{ inputs.version }}" ]]; then
+            current_tag="v$current_version"
+            current_subject="chore: release $current_tag"
+
+            if ! git rev-parse -q --verify "refs/tags/$current_tag" >/dev/null &&
+              git log --format=%s | grep -Fxq "$current_subject"; then
+              echo "main already contains an unpublished release commit for $current_tag; recover the in-flight release instead of starting a new patch bump" >&2
+              exit 1
+            fi
+          fi
+
+          release_version="$(bash scripts/release/resolve-version.sh "${{ inputs.version }}" "$current_version")"
+          release_tag="v$release_version"
+
+          if git rev-parse -q --verify "refs/tags/$release_tag" >/dev/null; then
+            echo "tag already exists: $release_tag" >&2
+            exit 1
+          fi
+
+          base_sha="$(git rev-parse HEAD)"
+
+          bash scripts/release/update-version.sh Cargo.toml Cargo.lock "$release_version"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore: release $release_tag"
+
+          release_sha="$(git rev-parse HEAD)"
+          git update-ref refs/heads/release-candidate "$release_sha"
+
+          {
+            echo "base_sha=$base_sha"
+            echo "release_sha=$release_sha"
+            echo "release_tag=$release_tag"
+            echo "release_version=$release_version"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Bundle release candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          git bundle create "$RUNNER_TEMP/release-candidate.bundle" refs/heads/release-candidate
+
+      - name: Upload release candidate bundle
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-candidate
+          path: ${{ runner.temp }}/release-candidate.bundle
+
+  verify-build:
+    name: Verify and build ${{ matrix.target }}
+    needs: prepare
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -18,16 +117,60 @@ jobs:
           - target: x86_64-unknown-linux-musl
             runner: ubuntu-latest
             use-cross: true
+            run-validation: true
           - target: aarch64-apple-darwin
             runner: macos-latest
             use-cross: false
+            run-validation: false
     steps:
-      - name: Checkout
+      - name: Checkout main
         uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Download release candidate bundle
+        uses: actions/download-artifact@v7
+        with:
+          name: release-candidate
+          path: ${{ runner.temp }}/release-candidate
+
+      - name: Restore release candidate
+        shell: bash
+        env:
+          RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          BASE_SHA: ${{ needs.prepare.outputs.base_sha }}
+        run: |
+          set -euo pipefail
+
+          bundle_path="${RUNNER_TEMP}/release-candidate/release-candidate.bundle"
+          git fetch "$bundle_path" "refs/heads/release-candidate:refs/heads/release-candidate"
+          git checkout --detach "$RELEASE_SHA"
+
+          actual_version="$(
+            awk '
+              /^\[package\]$/ { in_package = 1; next }
+              /^\[.*\]$/ { in_package = 0 }
+              in_package && /^version = "/ {
+                gsub(/^version = "/, "", $0)
+                gsub(/"$/, "", $0)
+                print
+                exit
+              }
+            ' Cargo.toml
+          )"
+
+          [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]]
+          [[ "$(git rev-parse HEAD^)" == "$BASE_SHA" ]]
+          [[ "$actual_version" == "$RELEASE_VERSION" ]]
+          [[ "v$actual_version" == "$RELEASE_TAG" ]]
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
+          components: rustfmt, clippy
           targets: ${{ matrix.target }}
 
       - name: Cache
@@ -35,23 +178,31 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
+      - name: Validate release candidate
+        if: ${{ matrix.run-validation }}
+        run: |
+          cargo fmt -- --check
+          cargo clippy -- -D warnings
+          cargo test
+
       - name: Install cross
-        if: matrix.use-cross
+        if: ${{ matrix.use-cross }}
         run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Build (cross)
-        if: matrix.use-cross
+        if: ${{ matrix.use-cross }}
         run: cross build --release --target ${{ matrix.target }}
 
       - name: Build (cargo)
-        if: "!matrix.use-cross"
+        if: ${{ !matrix.use-cross }}
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Archive
+        shell: bash
         run: |
-          cd target/${{ matrix.target }}/release
-          tar czf ../../../saferm-${{ matrix.target }}.tar.gz saferm
-          cd ../../..
+          set -euo pipefail
+          cd "target/${{ matrix.target }}/release"
+          tar czf "../../../saferm-${{ matrix.target }}.tar.gz" saferm
 
       - name: Upload artifact
         uses: actions/upload-artifact@v6
@@ -59,20 +210,120 @@ jobs:
           name: saferm-${{ matrix.target }}
           path: saferm-${{ matrix.target }}.tar.gz
 
-  release:
-    name: Create Release
-    needs: build
+  publish:
+    name: Publish release
+    needs:
+      - prepare
+      - verify-build
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     steps:
-      - name: Download artifacts
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PUSH_TOKEN }}
+
+      - name: Download release candidate bundle
         uses: actions/download-artifact@v7
         with:
+          name: release-candidate
+          path: ${{ runner.temp }}/release-candidate
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: saferm-*
           merge-multiple: true
+          path: ${{ runner.temp }}/release-artifacts
+
+      - name: Restore and validate release candidate
+        shell: bash
+        env:
+          RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          BASE_SHA: ${{ needs.prepare.outputs.base_sha }}
+        run: |
+          set -euo pipefail
+
+          bundle_path="${RUNNER_TEMP}/release-candidate/release-candidate.bundle"
+          git fetch "$bundle_path" "refs/heads/release-candidate:refs/heads/release-candidate"
+          git checkout --detach "$RELEASE_SHA"
+          git fetch --force --tags origin main
+
+          actual_version="$(
+            awk '
+              /^\[package\]$/ { in_package = 1; next }
+              /^\[.*\]$/ { in_package = 0 }
+              in_package && /^version = "/ {
+                gsub(/^version = "/, "", $0)
+                gsub(/"$/, "", $0)
+                print
+                exit
+              }
+            ' Cargo.toml
+          )"
+
+          [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]]
+          [[ "$(git rev-parse HEAD^)" == "$BASE_SHA" ]]
+          [[ "$actual_version" == "$RELEASE_VERSION" ]]
+          [[ "v$actual_version" == "$RELEASE_TAG" ]]
+
+          remote_main_sha="$(git rev-parse origin/main)"
+          if [[ "$remote_main_sha" != "$BASE_SHA" && "$remote_main_sha" != "$RELEASE_SHA" ]]; then
+            echo "origin/main is neither the prepared base nor the release commit" >&2
+            exit 1
+          fi
+
+          if git rev-parse -q --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
+            tag_sha="$(git rev-parse "$RELEASE_TAG^{}")"
+            if [[ "$tag_sha" != "$RELEASE_SHA" ]]; then
+              echo "tag $RELEASE_TAG already exists at a different commit" >&2
+              exit 1
+            fi
+          fi
+
+      - name: Push validated release commit and tag
+        shell: bash
+        env:
+          BASE_SHA: ${{ needs.prepare.outputs.base_sha }}
+          RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch --force --tags origin main
+
+          remote_main_sha="$(git rev-parse origin/main)"
+          if [[ "$remote_main_sha" == "$BASE_SHA" ]]; then
+            git push origin "$RELEASE_SHA:refs/heads/main"
+          elif [[ "$remote_main_sha" != "$RELEASE_SHA" ]]; then
+            echo "origin/main is neither the prepared base nor the release commit" >&2
+            exit 1
+          fi
+
+          if git rev-parse -q --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
+            tag_sha="$(git rev-parse "$RELEASE_TAG^{}")"
+            if [[ "$tag_sha" != "$RELEASE_SHA" ]]; then
+              echo "tag $RELEASE_TAG already exists at a different commit" >&2
+              exit 1
+            fi
+          else
+            git tag -a "$RELEASE_TAG" "$RELEASE_SHA" -m "$RELEASE_TAG"
+            git push origin "refs/tags/$RELEASE_TAG"
+          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.prepare.outputs.release_tag }}
+          target_commitish: ${{ needs.prepare.outputs.release_sha }}
           generate_release_notes: true
-          files: saferm-*.tar.gz
+          files: ${{ runner.temp }}/release-artifacts/saferm-*.tar.gz
+          token: ${{ secrets.RELEASE_PUSH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -83,18 +83,14 @@ Pull requests and pushes to `main` are checked automatically on both Ubuntu and 
 - `cargo clippy -- -D warnings`
 - `cargo test`
 
-When a version tag (`v*`) is pushed, the release workflow builds static binaries for 2 targets and publishes a GitHub Release:
+Releases are started manually from GitHub Actions via `Actions > Release > Run workflow`. The workflow always prepares the release from `main`, updates `Cargo.toml` and `Cargo.lock`, validates the release candidate, and builds the supported release artifacts before publish.
+
+Leave the version input empty to auto-bump the current patch version. Provide a version such as `1.2.0` to override the automatic bump. After approval from the GitHub `release` environment, the workflow publishes the prepared release by updating `main` when needed, ensuring the matching version tag (`v<release_version>`) exists, and creating the GitHub Release:
 
 | Target | Binary type |
 |--------|-------------|
 | `x86_64-unknown-linux-musl` | Static (musl, no glibc dependency) |
 | `aarch64-apple-darwin` | Native (Apple Silicon) |
-
-```bash
-# Create a release / リリースを作成
-git tag v1.2.0
-git push origin v1.2.0
-```
 
 ---
 
@@ -104,18 +100,14 @@ git push origin v1.2.0
 - `cargo clippy -- -D warnings`
 - `cargo test`
 
-バージョンタグ (`v*`) を push すると、リリースワークフローが2ターゲットのバイナリをビルドし GitHub Release を作成します:
+リリースは GitHub Actions の `Actions > Release > Run workflow` から手動で開始します。ワークフローは常に `main` からリリース候補を作成し、`Cargo.toml` と `Cargo.lock` を更新し、publish 前にリリース候補を検証して対応する release artifact をビルドします。
+
+version 入力を空のままにすると現在の patch バージョンを自動でインクリメントします。`1.2.0` のようなバージョンを指定すると自動 bump を上書きします。GitHub の `release` environment で承認されると、ワークフローは必要に応じて `main` を更新し、対応する version tag (`v<release_version>`) の存在を保証して、GitHub Release を公開します:
 
 | ターゲット | バイナリ種別 |
 |--------|-------------|
 | `x86_64-unknown-linux-musl` | 静的リンク (musl、glibc 依存なし) |
 | `aarch64-apple-darwin` | ネイティブ (Apple Silicon) |
-
-```bash
-# Create a release / リリースを作成
-git tag v1.2.0
-git push origin v1.2.0
-```
 
 ## Development / 開発
 

--- a/docs/plans/2026-05-23-release-workflow.md
+++ b/docs/plans/2026-05-23-release-workflow.md
@@ -1,0 +1,550 @@
+# Release Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace tag-push releases with a manual GitHub Actions release flow that computes the target version, validates a release candidate before publish, and only then pushes the release commit and tag to `main`.
+
+**Architecture:** Keep the release policy in `.github/workflows/release.yaml`, but move version resolution and manifest updates into small shell helpers under `scripts/release/` so the workflow logic stays readable. Preserve the exact validated release candidate across jobs by bundling the local git commit from the preparation step, then publish that same commit after environment approval.
+
+**Tech Stack:** GitHub Actions, POSIX shell, git bundle, Cargo, README documentation
+
+---
+
+### Task 1: Add release helper scripts with shell tests
+
+**Files:**
+- Create: `scripts/release/resolve-version.sh`
+- Create: `scripts/release/update-version.sh`
+- Create: `scripts/tests/release_helpers_test.sh`
+
+- [ ] **Step 1: Write the failing shell tests**
+
+Create `scripts/tests/release_helpers_test.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT/scripts/release/resolve-version.sh"
+source "$ROOT/scripts/release/update-version.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local label="$3"
+
+  if [[ "$actual" != "$expected" ]]; then
+    fail "$label: expected '$expected', got '$actual'"
+  fi
+}
+
+test_patch_bump_when_input_empty() {
+  local version
+  version="$(resolve_version "" "1.0.1")"
+  assert_eq "$version" "1.0.2" "empty input bumps patch"
+}
+
+test_explicit_version_wins() {
+  local version
+  version="$(resolve_version "2.0.0" "1.0.1")"
+  assert_eq "$version" "2.0.0" "explicit version is preserved"
+}
+
+test_invalid_version_fails() {
+  if resolve_version "1.0" "1.0.1" >/dev/null 2>&1; then
+    fail "invalid semver should fail"
+  fi
+}
+
+test_update_version_rewrites_manifest_and_lock() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' RETURN
+
+  cat >"$tmpdir/Cargo.toml" <<'EOF'
+[package]
+name = "saferm"
+version = "1.0.1"
+edition = "2024"
+EOF
+
+  cat >"$tmpdir/Cargo.lock" <<'EOF'
+version = 4
+
+[[package]]
+name = "saferm"
+version = "1.0.1"
+EOF
+
+  update_version_files "$tmpdir/Cargo.toml" "$tmpdir/Cargo.lock" "1.0.2"
+
+  assert_eq "$(grep '^version = ' "$tmpdir/Cargo.toml" | head -1)" 'version = "1.0.2"' "manifest version updated"
+  assert_eq "$(grep '^version = ' "$tmpdir/Cargo.lock" | tail -1)" 'version = "1.0.2"' "lockfile root package version updated"
+}
+
+main() {
+  test_patch_bump_when_input_empty
+  test_explicit_version_wins
+  test_invalid_version_fails
+  test_update_version_rewrites_manifest_and_lock
+  echo "release helper tests: ok"
+}
+
+main "$@"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/tests/release_helpers_test.sh`
+Expected: FAIL with `No such file or directory` while sourcing `scripts/release/resolve-version.sh`
+
+- [ ] **Step 3: Write the minimal helper implementations**
+
+Create `scripts/release/resolve-version.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+semver_pattern='^[0-9]+\.[0-9]+\.[0-9]+$'
+
+resolve_version() {
+  local requested="$1"
+  local current="$2"
+
+  if [[ -n "$requested" ]]; then
+    [[ "$requested" =~ $semver_pattern ]] || {
+      echo "invalid semver: $requested" >&2
+      return 1
+    }
+    printf '%s\n' "$requested"
+    return 0
+  fi
+
+  [[ "$current" =~ $semver_pattern ]] || {
+    echo "invalid current version: $current" >&2
+    return 1
+  }
+
+  IFS='.' read -r major minor patch <<<"$current"
+  printf '%s.%s.%s\n' "$major" "$minor" "$((patch + 1))"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  resolve_version "${1:-}" "${2:-}"
+fi
+```
+
+Create `scripts/release/update-version.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+update_version_files() {
+  local manifest="$1"
+  local lockfile="$2"
+  local version="$3"
+
+  sed -i.bak -E "0,/^version = \".*\"$/s//version = \"$version\"/" "$manifest"
+  rm -f "$manifest.bak"
+
+  awk -v version="$version" '
+    BEGIN { in_saferm = 0; updated = 0 }
+    /^\[\[package\]\]$/ { in_saferm = 0 }
+    /^name = "saferm"$/ { in_saferm = 1 }
+    in_saferm && /^version = ".*"$/ && !updated {
+      print "version = \"" version "\""
+      updated = 1
+      next
+    }
+    { print }
+  ' "$lockfile" >"$lockfile.tmp"
+  mv "$lockfile.tmp" "$lockfile"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  update_version_files "$1" "$2" "$3"
+fi
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash scripts/tests/release_helpers_test.sh`
+Expected: PASS with `release helper tests: ok`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/release/resolve-version.sh scripts/release/update-version.sh scripts/tests/release_helpers_test.sh
+git commit -m "chore: add release helper scripts"
+```
+
+### Task 2: Replace the release workflow with a manual publish flow
+
+**Files:**
+- Modify: `.github/workflows/release.yaml`
+- Test: `scripts/tests/release_helpers_test.sh`
+
+- [ ] **Step 1: Write the failing workflow assertions into the helper tests**
+
+Append this test to `scripts/tests/release_helpers_test.sh`:
+
+```bash
+test_resolve_version_rejects_prerelease_suffix() {
+  if resolve_version "1.0.2-rc1" "1.0.1" >/dev/null 2>&1; then
+    fail "prerelease versions should fail in the first implementation"
+  fi
+}
+```
+
+and call it from `main()`:
+
+```bash
+  test_resolve_version_rejects_prerelease_suffix
+```
+
+- [ ] **Step 2: Run test to verify it fails for the new rule**
+
+Run: `bash scripts/tests/release_helpers_test.sh`
+Expected: FAIL with `prerelease versions should fail in the first implementation`
+
+- [ ] **Step 3: Update the helper and replace `.github/workflows/release.yaml`**
+
+Keep `scripts/release/resolve-version.sh` semver validation strict, then replace `.github/workflows/release.yaml` with:
+
+```yaml
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (optional; defaults to patch bump)"
+        required: false
+        type: string
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  prepare:
+    name: Prepare release candidate
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.meta.outputs.tag }}
+      base_sha: ${{ steps.meta.outputs.base_sha }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Resolve version
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          current_version="$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -1)"
+          version="$(bash scripts/release/resolve-version.sh "${{ inputs.version }}" "$current_version")"
+          tag="v$version"
+          git fetch --tags origin
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "tag already exists: $tag" >&2
+            exit 1
+          fi
+          echo "version=$version" >>"$GITHUB_OUTPUT"
+          echo "tag=$tag" >>"$GITHUB_OUTPUT"
+          echo "base_sha=$(git rev-parse HEAD)" >>"$GITHUB_OUTPUT"
+
+      - name: Update version files
+        run: bash scripts/release/update-version.sh Cargo.toml Cargo.lock "${{ steps.meta.outputs.version }}"
+
+      - name: Create release commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore: release ${{ steps.meta.outputs.tag }}"
+
+      - name: Bundle release candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          git branch -f release-candidate HEAD
+          git bundle create release.bundle release-candidate ^"${{ steps.meta.outputs.base_sha }}"
+          git rev-parse HEAD >release_commit_sha.txt
+
+      - name: Upload release candidate
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-candidate
+          path: |
+            release.bundle
+            release_commit_sha.txt
+
+  verify-build:
+    name: Verify and build release candidate
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-latest
+            use_cross: true
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            use_cross: false
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Download release candidate
+        uses: actions/download-artifact@v7
+        with:
+          name: release-candidate
+
+      - name: Import release candidate commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch ./release.bundle 'refs/heads/release-candidate:refs/remotes/bundle/release-candidate'
+          git checkout "$(cat release_commit_sha.txt)"
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+          targets: ${{ matrix.target }}
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}-release
+
+      - name: Format check
+        run: cargo fmt -- --check
+
+      - name: Lint
+        run: cargo clippy -- -D warnings
+
+      - name: Test
+        run: cargo test
+
+      - name: Install cross
+        if: matrix.use_cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build (cross)
+        if: matrix.use_cross
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Build (cargo)
+        if: ${{ !matrix.use_cross }}
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "target/${{ matrix.target }}/release"
+          tar czf "../../../saferm-${{ matrix.target }}.tar.gz" saferm
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: saferm-${{ matrix.target }}
+          path: saferm-${{ matrix.target }}.tar.gz
+
+  publish:
+    name: Publish release
+    needs: [prepare, verify-build]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PUSH_TOKEN }}
+
+      - name: Download release candidate
+        uses: actions/download-artifact@v7
+        with:
+          name: release-candidate
+
+      - name: Download packaged artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: saferm-*
+          merge-multiple: true
+
+      - name: Verify main head and import release commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main --tags
+          current_main="$(git rev-parse origin/main)"
+          if [[ "$current_main" != "${{ needs.prepare.outputs.base_sha }}" ]]; then
+            echo "origin/main advanced from ${{ needs.prepare.outputs.base_sha }} to $current_main" >&2
+            exit 1
+          fi
+          git fetch ./release.bundle 'refs/heads/release-candidate:refs/remotes/bundle/release-candidate'
+          git checkout "$(cat release_commit_sha.txt)"
+
+      - name: Push release commit and tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          git push origin HEAD:main
+          git tag "${{ needs.prepare.outputs.tag }}"
+          git push origin "${{ needs.prepare.outputs.tag }}"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          generate_release_notes: true
+          files: saferm-*.tar.gz
+```
+
+- [ ] **Step 4: Run the local verification and helper tests**
+
+Run: `bash scripts/tests/release_helpers_test.sh && cargo fmt -- --check && cargo clippy -- -D warnings && cargo test`
+Expected: PASS, and `scripts/tests/release_helpers_test.sh` prints `release helper tests: ok`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/release.yaml scripts/release/resolve-version.sh scripts/release/update-version.sh scripts/tests/release_helpers_test.sh
+git commit -m "feat: add manual release workflow"
+```
+
+### Task 3: Update documentation for the new release flow
+
+**Files:**
+- Modify: `README.md`
+- Test: `.github/workflows/release.yaml`
+
+- [ ] **Step 1: Write the failing documentation expectation**
+
+In your notes, define the expected release section content:
+
+```text
+The README must no longer tell the operator to create and push a tag manually.
+It must say that releases are started from Actions, that version input is optional,
+that an empty version performs a patch bump, and that release publishing waits for
+the GitHub `release` environment approval.
+```
+
+- [ ] **Step 2: Verify the current README still documents the old flow**
+
+Run: `rg -n "git tag|git push origin v|Actions > Release|patch bump|environment" README.md`
+Expected: matches only the old `git tag v1.2.0` / `git push origin v1.2.0` instructions, and no `Actions > Release` guidance
+
+- [ ] **Step 3: Replace the README release instructions**
+
+Update the release section in `README.md` to:
+
+```md
+When you want to publish a release, run the `Release` workflow from GitHub Actions.
+The workflow always releases from `main`, updates `Cargo.toml` and `Cargo.lock`,
+validates the release candidate, and waits for approval from the `release`
+environment before publishing.
+
+- Leave the version input empty to bump the patch version automatically
+- Provide a version such as `1.2.0` to override the automatic bump
+
+After approval, the workflow pushes the release commit to `main`, creates the
+matching `v*` tag, builds release artifacts for the supported targets, and
+publishes the GitHub Release.
+
+```bash
+# Release from GitHub Actions
+Actions > Release > Run workflow
+```
+```
+
+- [ ] **Step 4: Run the documentation and code verification**
+
+Run: `rg -n "Actions > Release|release environment" README.md && ! rg -n "git tag v[0-9]" README.md && bash scripts/tests/release_helpers_test.sh && cargo fmt -- --check && cargo clippy -- -D warnings && cargo test`
+Expected: README references `Actions > Release` and the release environment, does not keep the old manual tag commands, and all checks pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document manual release workflow"
+```
+
+### Task 4: Final pre-merge verification and operator handoff
+
+**Files:**
+- Modify: none
+- Test: `.github/workflows/release.yaml`
+
+- [ ] **Step 1: Re-run the full implementation verification**
+
+Run:
+
+```bash
+bash scripts/tests/release_helpers_test.sh
+cargo fmt -- --check
+cargo clippy -- -D warnings
+cargo test
+```
+
+Expected: all commands succeed with no modified files left behind
+
+- [ ] **Step 2: Review the final diff for the intended surface area**
+
+Run:
+
+```bash
+git diff --stat main...
+git diff main... -- .github/workflows/release.yaml README.md scripts/release scripts/tests
+```
+
+Expected: only the new manual release flow, helper scripts, tests, and README changes appear
+
+- [ ] **Step 3: Document the GitHub-side setup that cannot be committed**
+
+Add this handoff note to the PR description or implementation summary:
+
+```text
+Post-merge GitHub configuration:
+- create a `release` environment
+- require reviewer approval for the environment
+- optionally disable self-review
+- store the publish credential as `RELEASE_PUSH_TOKEN`
+- allow only that bot or GitHub App to bypass `main` protection for release pushes
+```
+
+- [ ] **Step 4: Commit any final touch-ups**
+
+```bash
+git status --short
+```
+
+Expected: no output. If there is output, stage only the intended follow-up fixes and commit with a focused message.

--- a/docs/specs/release-workflow.md
+++ b/docs/specs/release-workflow.md
@@ -1,0 +1,215 @@
+# Release Workflow Spec
+
+## Summary
+
+Replace the current tag-push-driven release process with a single manually triggered GitHub Actions workflow that:
+
+- allows releases to be initiated independently from merges to `main`
+- keeps the released version, `Cargo.toml`, `Cargo.lock`, CLI `--version`, and Git tag aligned
+- verifies the release commit before anything is pushed to `main`
+- requires explicit GitHub environment approval before publishing
+
+The resulting operator flow is:
+
+1. Open `Actions > Release`
+2. Optionally enter a version
+3. Run the workflow
+4. Approve the `release` environment
+5. Let the workflow push the release commit, tag it, and publish the GitHub Release
+
+If no version is provided, the workflow increments the patch version from `Cargo.toml`.
+
+## Context
+
+The current process requires:
+
+1. merge changes into `main`
+2. prepare a separate version bump
+3. merge the version bump
+4. create and push a release tag
+
+This is awkward because release timing is intentionally separate from merge timing, while `mise` distribution still depends on GitHub tags and releases.
+
+## Goals
+
+- Release from `main` only, on demand
+- Require just one operator action plus approval
+- Keep repository version metadata and released version identical
+- Avoid pushing a version bump commit if release validation fails
+- Preserve GitHub Releases and tags as the distribution source for `mise`
+- Keep direct human pushes to `main` disallowed
+
+## Non-Goals
+
+- Reusing CI steps automatically from the existing CI workflow
+- Releasing from arbitrary branches
+- Supporting prerelease channels in the first version of this design
+- Eliminating GitHub environment configuration work outside the repository
+
+## Proposed Design
+
+### 1. Replace release trigger model
+
+Remove the current `push.tags: ["v*"]` release entrypoint and replace it with a dedicated `workflow_dispatch` workflow.
+
+Inputs:
+
+- `version` (optional): explicit semver such as `1.2.0`
+
+Behavior:
+
+- if `version` is empty, read the current version from `Cargo.toml` and increment the patch component
+- derive the Git tag name as `v<version>`
+
+### 2. Use `Cargo.toml` as the single source of truth
+
+The workflow updates:
+
+- `Cargo.toml`
+- `Cargo.lock`
+
+These files are updated before release validation so that:
+
+- `saferm --version` matches the release version
+- the release commit in `main` matches the published tag
+- repository history reflects exactly what was released
+
+### 3. Validate before publishing
+
+The workflow creates a local release commit such as:
+
+`chore: release v1.0.2`
+
+This commit is not pushed immediately. Validation runs against that commit first.
+
+Validation includes:
+
+- format check
+- lint
+- test
+- release build
+- packaging of release artifacts
+
+If any step fails, the workflow exits without pushing the commit or tag.
+
+### 4. Require protected publishing
+
+The final publish job uses `environment: release`.
+
+GitHub-side requirements:
+
+- configure a `release` environment
+- require reviewer approval for that environment
+- optionally disallow self-review
+
+Publishing credentials:
+
+- use a dedicated bot or GitHub App credential for the publish step
+- allow only that actor to bypass `main` branch protection or rulesets
+
+This ensures:
+
+- normal development still requires PRs
+- only the approved release workflow can add the release commit to `main`
+
+### 5. Publish atomically from the validated commit
+
+After approval, the workflow:
+
+1. confirms `origin/main` has not moved since workflow preparation
+2. pushes the validated release commit to `main`
+3. tags that exact commit as `v<version>`
+4. pushes the tag
+5. creates the GitHub Release and uploads built artifacts
+
+If `origin/main` changed before publish, the workflow fails rather than publishing from a stale base.
+
+## Workflow Structure
+
+### `prepare`
+
+Responsibilities:
+
+- check out `main`
+- resolve the target version
+- validate semver format when explicit input is provided
+- fail if the tag already exists
+- update `Cargo.toml` and `Cargo.lock`
+- create the local release commit
+- expose the resolved version, tag, base SHA, and release commit SHA as outputs
+
+### `verify-build`
+
+Responsibilities:
+
+- run on the release commit created in `prepare`
+- run verification commands
+- build release artifacts for the supported targets
+- archive artifacts for later publication
+
+This job intentionally owns its own release validation set. It does not try to automatically mirror future CI workflow jobs.
+
+### `publish`
+
+Responsibilities:
+
+- require `environment: release`
+- re-check `origin/main`
+- push the release commit to `main`
+- push the tag
+- create the GitHub Release from the same commit
+
+## Version Rules
+
+- explicit `version` input wins when provided
+- empty `version` input triggers patch increment from the current `Cargo.toml` value
+- only stable semver is supported initially
+- tag names always use the `v` prefix
+
+Examples:
+
+- `1.0.1` with empty input becomes `1.0.2`
+- explicit input `2.0.0` produces tag `v2.0.0`
+
+## Failure Semantics
+
+- invalid semver input: fail in `prepare`
+- existing tag: fail in `prepare`
+- version file update failure: fail in `prepare`
+- validation failure: fail in `verify-build`, push nothing
+- `main` moved before publish: fail in `publish`, push nothing
+- release creation failure after commit/tag push: manual follow-up may be required, but the repository state remains consistent because the tag points at the committed release version
+
+## Repository Changes
+
+Planned repository changes:
+
+- replace the existing release workflow with a manual release workflow
+- add helper script(s) for version calculation and version file updates if shell-only YAML becomes too brittle
+- update README release instructions to describe the manual workflow and approval gate
+
+No change is planned to the CI workflow beyond whatever is needed to keep release validation readable and maintainable.
+
+## Operational Notes
+
+- operators should release only from the current `main`
+- version bumps happen only through the release workflow
+- regular feature PRs should not edit `Cargo.toml` version unless intentionally preparing a release-related change
+- environment approval is the explicit release control point
+
+## Testing Plan
+
+Implementation should be validated with at least these cases:
+
+1. no version input: patch bump is computed correctly
+2. explicit version input: chosen version is applied consistently
+3. duplicate tag: workflow fails before mutation
+4. validation failure: no commit or tag is pushed
+5. `main` advanced before publish: workflow aborts publish
+
+## Open Questions Resolved
+
+- Release timing remains independent from merge timing: yes
+- `mise` distribution via GitHub tags/releases remains supported: yes
+- `Cargo.toml` version and released version remain unified: yes
+- CI and release validation are not forcibly unified: yes

--- a/scripts/release/resolve-version.sh
+++ b/scripts/release/resolve-version.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+semver_pattern='^[0-9]+\.[0-9]+\.[0-9]+$'
+
+resolve_version() {
+  local requested="$1"
+  local current="$2"
+
+  if [[ -n "$requested" ]]; then
+    [[ "$requested" =~ $semver_pattern ]] || {
+      echo "invalid semver: $requested" >&2
+      return 1
+    }
+    printf '%s\n' "$requested"
+    return 0
+  fi
+
+  [[ "$current" =~ $semver_pattern ]] || {
+    echo "invalid current version: $current" >&2
+    return 1
+  }
+
+  IFS='.' read -r major minor patch <<<"$current"
+  printf '%s.%s.%s\n' "$major" "$minor" "$((patch + 1))"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  resolve_version "${1:-}" "${2:-}"
+fi

--- a/scripts/release/resolve-version.sh
+++ b/scripts/release/resolve-version.sh
@@ -3,26 +3,42 @@ set -euo pipefail
 
 semver_pattern='^[0-9]+\.[0-9]+\.[0-9]+$'
 
+parse_semver() {
+  local version="$1"
+  local prefix="$2"
+
+  [[ "$version" =~ $semver_pattern ]] || {
+    echo "invalid $prefix version: $version" >&2
+    return 1
+  }
+
+  IFS='.' read -r major minor patch <<<"$version"
+  printf '%s %s %s\n' "$major" "$minor" "$patch"
+}
+
 resolve_version() {
   local requested="$1"
   local current="$2"
+  local current_major current_minor current_patch
+
+  read -r current_major current_minor current_patch < <(parse_semver "$current" "current")
 
   if [[ -n "$requested" ]]; then
-    [[ "$requested" =~ $semver_pattern ]] || {
-      echo "invalid semver: $requested" >&2
+    local requested_major requested_minor requested_patch
+    read -r requested_major requested_minor requested_patch < <(parse_semver "$requested" "requested")
+
+    if (( requested_major < current_major )) ||
+      (( requested_major == current_major && requested_minor < current_minor )) ||
+      (( requested_major == current_major && requested_minor == current_minor && requested_patch < current_patch )); then
+      echo "requested version $requested is lower than current version $current" >&2
       return 1
-    }
+    fi
+
     printf '%s\n' "$requested"
     return 0
   fi
 
-  [[ "$current" =~ $semver_pattern ]] || {
-    echo "invalid current version: $current" >&2
-    return 1
-  }
-
-  IFS='.' read -r major minor patch <<<"$current"
-  printf '%s.%s.%s\n' "$major" "$minor" "$((patch + 1))"
+  printf '%s.%s.%s\n' "$current_major" "$current_minor" "$((current_patch + 1))"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/scripts/release/update-version.sh
+++ b/scripts/release/update-version.sh
@@ -9,8 +9,16 @@ update_version_files() {
   local lockfile_tmp="$lockfile.tmp"
 
   awk -v version="$version" '
-    BEGIN { updated = 0 }
-    !updated && /^version = ".*"$/ {
+    BEGIN { in_package = 0; updated = 0 }
+    /^\[package\]$/ {
+      in_package = 1
+      print
+      next
+    }
+    /^\[.*\]$/ {
+      in_package = 0
+    }
+    in_package && !updated && /^version = ".*"$/ {
       print "version = \"" version "\""
       updated = 1
       next

--- a/scripts/release/update-version.sh
+++ b/scripts/release/update-version.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+update_version_files() {
+  local manifest="$1"
+  local lockfile="$2"
+  local version="$3"
+
+  sed -i.bak -E "1,/^version = \".*\"$/s/^version = \".*\"$/version = \"$version\"/" "$manifest"
+  rm -f "$manifest.bak"
+
+  awk -v version="$version" '
+    BEGIN { in_saferm = 0; updated = 0 }
+    /^\[\[package\]\]$/ { in_saferm = 0 }
+    /^name = "saferm"$/ { in_saferm = 1 }
+    in_saferm && /^version = ".*"$/ && !updated {
+      print "version = \"" version "\""
+      updated = 1
+      next
+    }
+    { print }
+  ' "$lockfile" >"$lockfile.tmp"
+  mv "$lockfile.tmp" "$lockfile"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  update_version_files "$1" "$2" "$3"
+fi

--- a/scripts/release/update-version.sh
+++ b/scripts/release/update-version.sh
@@ -5,9 +5,29 @@ update_version_files() {
   local manifest="$1"
   local lockfile="$2"
   local version="$3"
+  local manifest_tmp="$manifest.tmp"
+  local lockfile_tmp="$lockfile.tmp"
 
-  sed -i.bak -E "1,/^version = \".*\"$/s/^version = \".*\"$/version = \"$version\"/" "$manifest"
-  rm -f "$manifest.bak"
+  awk -v version="$version" '
+    BEGIN { updated = 0 }
+    !updated && /^version = ".*"$/ {
+      print "version = \"" version "\""
+      updated = 1
+      next
+    }
+    { print }
+    END { if (!updated) exit 1 }
+  ' "$manifest" >"$manifest_tmp" || {
+    rm -f "$manifest_tmp" "$lockfile_tmp"
+    echo "failed to update manifest version in $manifest" >&2
+    return 1
+  }
+
+  if cmp -s "$manifest" "$manifest_tmp"; then
+    rm -f "$manifest_tmp" "$lockfile_tmp"
+    echo "manifest version unchanged in $manifest" >&2
+    return 1
+  fi
 
   awk -v version="$version" '
     BEGIN { in_saferm = 0; updated = 0 }
@@ -19,8 +39,21 @@ update_version_files() {
       next
     }
     { print }
-  ' "$lockfile" >"$lockfile.tmp"
-  mv "$lockfile.tmp" "$lockfile"
+    END { if (!updated) exit 1 }
+  ' "$lockfile" >"$lockfile_tmp" || {
+    rm -f "$manifest_tmp" "$lockfile_tmp"
+    echo "failed to update saferm package version in $lockfile" >&2
+    return 1
+  }
+
+  if cmp -s "$lockfile" "$lockfile_tmp"; then
+    rm -f "$manifest_tmp" "$lockfile_tmp"
+    echo "saferm package version unchanged in $lockfile" >&2
+    return 1
+  fi
+
+  mv "$manifest_tmp" "$manifest"
+  mv "$lockfile_tmp" "$lockfile"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/scripts/tests/release_helpers_test.sh
+++ b/scripts/tests/release_helpers_test.sh
@@ -64,11 +64,62 @@ EOF
   assert_eq "$(grep '^version = ' "$tmpdir/Cargo.lock" | tail -1)" 'version = "1.0.2"' "lockfile root package version updated"
 }
 
+test_update_version_fails_when_manifest_version_missing() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap "rm -rf '$tmpdir'" RETURN
+
+  cat >"$tmpdir/Cargo.toml" <<'EOF'
+[package]
+name = "saferm"
+edition = "2024"
+EOF
+
+  cat >"$tmpdir/Cargo.lock" <<'EOF'
+version = 4
+
+[[package]]
+name = "saferm"
+version = "1.0.1"
+EOF
+
+  if update_version_files "$tmpdir/Cargo.toml" "$tmpdir/Cargo.lock" "1.0.2" >/dev/null 2>&1; then
+    fail "missing manifest version should fail"
+  fi
+}
+
+test_update_version_fails_when_lockfile_saferm_package_missing() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap "rm -rf '$tmpdir'" RETURN
+
+  cat >"$tmpdir/Cargo.toml" <<'EOF'
+[package]
+name = "saferm"
+version = "1.0.1"
+edition = "2024"
+EOF
+
+  cat >"$tmpdir/Cargo.lock" <<'EOF'
+version = 4
+
+[[package]]
+name = "another-package"
+version = "1.0.1"
+EOF
+
+  if update_version_files "$tmpdir/Cargo.toml" "$tmpdir/Cargo.lock" "1.0.2" >/dev/null 2>&1; then
+    fail "missing saferm package in lockfile should fail"
+  fi
+}
+
 main() {
   test_patch_bump_when_input_empty
   test_explicit_version_wins
   test_invalid_version_fails
   test_update_version_rewrites_manifest_and_lock
+  test_update_version_fails_when_manifest_version_missing
+  test_update_version_fails_when_lockfile_saferm_package_missing
   echo "release helper tests: ok"
 }
 

--- a/scripts/tests/release_helpers_test.sh
+++ b/scripts/tests/release_helpers_test.sh
@@ -88,6 +88,33 @@ EOF
   fi
 }
 
+test_update_version_fails_when_package_version_missing_but_other_table_has_version() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap "rm -rf '$tmpdir'" RETURN
+
+  cat >"$tmpdir/Cargo.toml" <<'EOF'
+[package]
+name = "saferm"
+edition = "2024"
+
+[metadata.release]
+version = "9.9.9"
+EOF
+
+  cat >"$tmpdir/Cargo.lock" <<'EOF'
+version = 4
+
+[[package]]
+name = "saferm"
+version = "1.0.1"
+EOF
+
+  if update_version_files "$tmpdir/Cargo.toml" "$tmpdir/Cargo.lock" "1.0.2" >/dev/null 2>&1; then
+    fail "missing package version should fail even when another table has version"
+  fi
+}
+
 test_update_version_fails_when_lockfile_saferm_package_missing() {
   local tmpdir
   tmpdir="$(mktemp -d)"
@@ -119,6 +146,7 @@ main() {
   test_invalid_version_fails
   test_update_version_rewrites_manifest_and_lock
   test_update_version_fails_when_manifest_version_missing
+  test_update_version_fails_when_package_version_missing_but_other_table_has_version
   test_update_version_fails_when_lockfile_saferm_package_missing
   echo "release helper tests: ok"
 }

--- a/scripts/tests/release_helpers_test.sh
+++ b/scripts/tests/release_helpers_test.sh
@@ -32,6 +32,18 @@ test_explicit_version_wins() {
   assert_eq "$version" "2.0.0" "explicit version is preserved"
 }
 
+test_same_version_is_allowed_for_recovery() {
+  local version
+  version="$(resolve_version "1.0.1" "1.0.1")"
+  assert_eq "$version" "1.0.1" "same explicit version is allowed for recovery"
+}
+
+test_explicit_version_downgrade_fails() {
+  if resolve_version "1.0.0" "1.0.1" >/dev/null 2>&1; then
+    fail "explicit version downgrade should fail"
+  fi
+}
+
 test_invalid_version_fails() {
   if resolve_version "1.0" "1.0.1" >/dev/null 2>&1; then
     fail "invalid semver should fail"
@@ -149,6 +161,8 @@ EOF
 main() {
   test_patch_bump_when_input_empty
   test_explicit_version_wins
+  test_same_version_is_allowed_for_recovery
+  test_explicit_version_downgrade_fails
   test_invalid_version_fails
   test_resolve_version_rejects_prerelease_suffix
   test_update_version_rewrites_manifest_and_lock

--- a/scripts/tests/release_helpers_test.sh
+++ b/scripts/tests/release_helpers_test.sh
@@ -38,6 +38,12 @@ test_invalid_version_fails() {
   fi
 }
 
+test_resolve_version_rejects_prerelease_suffix() {
+  if resolve_version "1.0.2-rc1" "1.0.1" >/dev/null 2>&1; then
+    fail "prerelease versions should fail in the first implementation"
+  fi
+}
+
 test_update_version_rewrites_manifest_and_lock() {
   local tmpdir
   tmpdir="$(mktemp -d)"
@@ -144,6 +150,7 @@ main() {
   test_patch_bump_when_input_empty
   test_explicit_version_wins
   test_invalid_version_fails
+  test_resolve_version_rejects_prerelease_suffix
   test_update_version_rewrites_manifest_and_lock
   test_update_version_fails_when_manifest_version_missing
   test_update_version_fails_when_package_version_missing_but_other_table_has_version

--- a/scripts/tests/release_helpers_test.sh
+++ b/scripts/tests/release_helpers_test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT/scripts/release/resolve-version.sh"
+source "$ROOT/scripts/release/update-version.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local label="$3"
+
+  if [[ "$actual" != "$expected" ]]; then
+    fail "$label: expected '$expected', got '$actual'"
+  fi
+}
+
+test_patch_bump_when_input_empty() {
+  local version
+  version="$(resolve_version "" "1.0.1")"
+  assert_eq "$version" "1.0.2" "empty input bumps patch"
+}
+
+test_explicit_version_wins() {
+  local version
+  version="$(resolve_version "2.0.0" "1.0.1")"
+  assert_eq "$version" "2.0.0" "explicit version is preserved"
+}
+
+test_invalid_version_fails() {
+  if resolve_version "1.0" "1.0.1" >/dev/null 2>&1; then
+    fail "invalid semver should fail"
+  fi
+}
+
+test_update_version_rewrites_manifest_and_lock() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap "rm -rf '$tmpdir'" RETURN
+
+  cat >"$tmpdir/Cargo.toml" <<'EOF'
+[package]
+name = "saferm"
+version = "1.0.1"
+edition = "2024"
+EOF
+
+  cat >"$tmpdir/Cargo.lock" <<'EOF'
+version = 4
+
+[[package]]
+name = "saferm"
+version = "1.0.1"
+EOF
+
+  update_version_files "$tmpdir/Cargo.toml" "$tmpdir/Cargo.lock" "1.0.2"
+
+  assert_eq "$(grep '^version = ' "$tmpdir/Cargo.toml" | head -1)" 'version = "1.0.2"' "manifest version updated"
+  assert_eq "$(grep '^version = ' "$tmpdir/Cargo.lock" | tail -1)" 'version = "1.0.2"' "lockfile root package version updated"
+}
+
+main() {
+  test_patch_bump_when_input_empty
+  test_explicit_version_wins
+  test_invalid_version_fails
+  test_update_version_rewrites_manifest_and_lock
+  echo "release helper tests: ok"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- replace tag-push releases with a manual workflow_dispatch release flow
- add release helper scripts and shell coverage for version resolution and manifest updates
- document the release workflow and capture the approved spec/implementation plan

## Test Plan
- [x] bash scripts/tests/release_helpers_test.sh
- [x] cargo fmt -- --check
- [x] cargo clippy -- -D warnings
- [x] cargo test

## Post-merge GitHub configuration
- create a `release` environment
- require reviewer approval for the environment
- optionally disable self-review
- store the publish credential as `RELEASE_PUSH_TOKEN`
- allow only that bot or GitHub App to bypass `main` protection for release pushes