### PR TITLE
fix: validate release publish token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -290,13 +290,25 @@ jobs:
     environment: release
     permissions:
       contents: write
+    env:
+      RELEASE_PUSH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN }}
     steps:
+      - name: Validate publish credentials
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${RELEASE_PUSH_TOKEN:-}" ]]; then
+            echo "RELEASE_PUSH_TOKEN is not configured. Add it as a repository secret or a secret on the 'release' environment, then rerun the Release workflow." >&2
+            exit 1
+          fi
+
       - name: Checkout main
         uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PUSH_TOKEN }}
+          token: ${{ env.RELEASE_PUSH_TOKEN }}
 
       - name: Download release candidate bundle
         uses: actions/download-artifact@v7
@@ -397,4 +409,4 @@ jobs:
           target_commitish: ${{ needs.prepare.outputs.release_sha }}
           generate_release_notes: true
           files: ${{ runner.temp }}/release-artifacts/saferm-*.tar.gz
-          token: ${{ secrets.RELEASE_PUSH_TOKEN }}
+          token: ${{ env.RELEASE_PUSH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Pull requests and pushes to `main` are checked automatically on both Ubuntu and 
 
 Releases are started manually from GitHub Actions via `Actions > Release > Run workflow`. The workflow always prepares the release from `main`, updates `Cargo.toml` and `Cargo.lock`, validates the release candidate, and builds the supported release artifacts before publish.
 
+Before the first release, create the GitHub `release` environment, add reviewer rules if you want approval, and store a publish credential as the `RELEASE_PUSH_TOKEN` repository secret or `release` environment secret.
+
 Leave the version input empty to auto-bump the current patch version. Provide a version such as `1.2.0` to override the automatic bump. After approval from the GitHub `release` environment, the workflow publishes the prepared release by updating `main` when needed, ensuring the matching version tag (`v<release_version>`) exists, and creating the GitHub Release:
 
 | Target | Binary type |
@@ -101,6 +103,8 @@ Leave the version input empty to auto-bump the current patch version. Provide a 
 - `cargo test`
 
 リリースは GitHub Actions の `Actions > Release > Run workflow` から手動で開始します。ワークフローは常に `main` からリリース候補を作成し、`Cargo.toml` と `Cargo.lock` を更新し、publish 前にリリース候補を検証して対応する release artifact をビルドします。
+
+初回リリース前に、GitHub の `release` environment を作成し、承認を入れたい場合は reviewer rule を設定し、publish 用 credential を `RELEASE_PUSH_TOKEN` という repository secret か `release` environment secret として登録してください。
 
 version 入力を空のままにすると現在の patch バージョンを自動でインクリメントします。`1.2.0` のようなバージョンを指定すると自動 bump を上書きします。GitHub の `release` environment で承認されると、ワークフローは必要に応じて `main` を更新し、対応する version tag (`v<release_version>`) の存在を保証して、GitHub Release を公開します:
 


### PR DESCRIPTION
## Summary
- fail early with a clear message when `RELEASE_PUSH_TOKEN` is missing
- reuse the validated publish token across checkout and release steps
- document the required release secret/environment setup in the README

## Test Plan
- [x] ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yaml")'
- [x] rg -n "RELEASE_PUSH_TOKEN|release environment" .github/workflows/release.yaml README.md