### PR TITLE
fix: use GitHub App for release publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -290,13 +290,39 @@ jobs:
     environment: release
     permissions:
       contents: write
+    env:
+      RELEASE_APP_CLIENT_ID: ${{ vars.RELEASE_APP_CLIENT_ID }}
+      RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
     steps:
+      - name: Validate GitHub App configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${RELEASE_APP_CLIENT_ID:-}" ]]; then
+            echo "RELEASE_APP_CLIENT_ID is not configured. Add the GitHub App client ID as a repository variable before rerunning the Release workflow." >&2
+            exit 1
+          fi
+
+          if [[ -z "${RELEASE_APP_PRIVATE_KEY:-}" ]]; then
+            echo "RELEASE_APP_PRIVATE_KEY is not configured. Add the GitHub App private key as a repository or 'release' environment secret before rerunning the Release workflow." >&2
+            exit 1
+          fi
+
+      - name: Create release app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ env.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ env.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Checkout main
         uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PUSH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Download release candidate bundle
         uses: actions/download-artifact@v7
@@ -397,4 +423,4 @@ jobs:
           target_commitish: ${{ needs.prepare.outputs.release_sha }}
           generate_release_notes: true
           files: ${{ runner.temp }}/release-artifacts/saferm-*.tar.gz
-          token: ${{ secrets.RELEASE_PUSH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Pull requests and pushes to `main` are checked automatically on both Ubuntu and 
 
 Releases are started manually from GitHub Actions via `Actions > Release > Run workflow`. The workflow always prepares the release from `main`, updates `Cargo.toml` and `Cargo.lock`, validates the release candidate, and builds the supported release artifacts before publish.
 
+Before the first release, create and install a GitHub App for this repository, grant it `Contents: Read and write`, add the app to the `main` ruleset bypass list as `Always allow`, store the app client ID in the `RELEASE_APP_CLIENT_ID` repository variable, and store the private key in the `RELEASE_APP_PRIVATE_KEY` repository secret or `release` environment secret.
+
 Leave the version input empty to auto-bump the current patch version. Provide a version such as `1.2.0` to override the automatic bump. After approval from the GitHub `release` environment, the workflow publishes the prepared release by updating `main` when needed, ensuring the matching version tag (`v<release_version>`) exists, and creating the GitHub Release:
 
 | Target | Binary type |
@@ -101,6 +103,8 @@ Leave the version input empty to auto-bump the current patch version. Provide a 
 - `cargo test`
 
 リリースは GitHub Actions の `Actions > Release > Run workflow` から手動で開始します。ワークフローは常に `main` からリリース候補を作成し、`Cargo.toml` と `Cargo.lock` を更新し、publish 前にリリース候補を検証して対応する release artifact をビルドします。
+
+初回リリース前に、この repository 用の GitHub App を作成して install し、`Contents: Read and write` を付与し、`main` ruleset の bypass list にその App を `Always allow` で追加し、app client ID を `RELEASE_APP_CLIENT_ID` repository variable に、private key を `RELEASE_APP_PRIVATE_KEY` repository secret か `release` environment secret に登録してください。
 
 version 入力を空のままにすると現在の patch バージョンを自動でインクリメントします。`1.2.0` のようなバージョンを指定すると自動 bump を上書きします。GitHub の `release` environment で承認されると、ワークフローは必要に応じて `main` を更新し、対応する version tag (`v<release_version>`) の存在を保証して、GitHub Release を公開します:
 


### PR DESCRIPTION
## Summary
- switch the release publish job from a stored push token to a GitHub App installation token
- fail early with clear messages when the GitHub App client ID or private key is missing
- document the GitHub App setup required for the release workflow

## Test Plan
- [x] ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yaml")'
- [x] rg -n "RELEASE_APP_CLIENT_ID|RELEASE_APP_PRIVATE_KEY|GitHub App" .github/workflows/release.yaml README.md